### PR TITLE
Making Documentation Link work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>github-workflow-collector</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Github Collector Microservice collecting stats from Github</description>
-  <url>https://hygieia.github.io/Hygieia/getting_started.html</url>
+  <url>https://hygieia.github.io/hygieia/getting_started.html</url>
   <packaging>jar</packaging>
   <version>1.0.0</version>
 


### PR DESCRIPTION
The previous link was a 404... this is the fix.

Signed-off-by: Ken Sipe <kensipe@gmail.com>